### PR TITLE
Replace non-explicit '-' by more explicit text

### DIFF
--- a/mopidy_party/static/controller.js
+++ b/mopidy_party/static/controller.js
@@ -18,7 +18,7 @@ angular.module('partyApp', [])
     length : 0,
     track  : {
       length : 0,
-      name   : '-'
+      name   : 'Nothing playing, add some songs to get the party going!'
     }
   };
 


### PR DESCRIPTION
By default, currentState.track.name shows a " - " before any songs are played.
This is very confusing to first time users if no song is playing, as one doesn't know if it's an area one should click, or, if it's supposed to be an informative area, if the software is working properly.
This patch simply replaces the non-explicit dash by a more explicit text, encouraging users to play some music.