### PR TITLE
Add browse when search string is empty, and on load.

### DIFF
--- a/mopidy_party/static/index.html
+++ b/mopidy_party/static/index.html
@@ -69,6 +69,11 @@
           </small>
         </li>
       </ul>
+      <div class="mt-1 mx-auto" style="width: 64px;">
+        <button type="button" class="btn" ng-model="button" ng-click="lookupOnePageOfTracks()" ng-show="tracksToLookup.length">
+          More
+        </button>
+      </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
This refactors out a few methods shared between browse and search results, and calls browse() to list all local tracks when the search string is empty.