### PR TITLE
Update for browse-results. Config reading service. Configurable max queue length and result paging size. Non-blocking backend requests.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,12 +38,13 @@ Configuration
 
     [party]
     enabled = true
-    votes_to_skip = 3  # Votes needed from different users to allow skipping a song.
-    max_tracks = 0     # Maximum number of tracks that can be added by a single user in a row. 0 to disable.
-    hide_pause = false # Change to true to hide the pause button
-    hide_skip = false  # Change to true to hide the skip button 
-    style = dark.css   # Stylesheet to use. Also embedded is original.css (light theme)
-    max_results = 50   # Maximum number of tracks to show when searching / browsing on a single page
+    votes_to_skip = 3     # Votes needed from different users to allow skipping a song.
+    max_tracks = 0        # Maximum number of tracks that can be added by a single user in a row. 0 to disable.
+    hide_pause = false    # Change to true to hide the pause button
+    hide_skip = false     # Change to true to hide the skip button 
+    style = dark.css      # Stylesheet to use. Also embedded is original.css (light theme)
+    max_results = 50      # Maximum number of tracks to show when searching / browsing on a single page
+    max_queue_length = 0  # Maximum number of tracks queued at the same time, 0 for unlimited
 
 Project resources
 =================

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Configuration
     hide_pause = false # Change to true to hide the pause button
     hide_skip = false  # Change to true to hide the skip button 
     style = dark.css   # Stylesheet to use. Also embedded is original.css (light theme)
-	max_results = 50   # Maximum number of tracks to show when searching / browsing on a single page
+    max_results = 50   # Maximum number of tracks to show when searching / browsing on a single page
 
 Project resources
 =================
@@ -56,10 +56,9 @@ Project resources
 Developer information
 =====================
 
-The RequestHandler 'config' makes `mopidy.conf` `[party]` configuration available via `http GET` requests. Useful if you want to make aspects of the controller configurable.
+The RequestHandler 'config' makes ``mopidy.conf``'s section for the ``[party]`` configuration available via ``http GET`` requests. Useful if you want to make aspects of the controller configurable.
 
-Example: The controller uses the below request, to read the `mopidy.conf` `[party]` section's `max_results` value.
-.. code-block:: javascript
+Example: The controller uses the below request, to read the ``max_results`` value.::
 
 $http.get('/party/config?key=max_results')
  

--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ Configuration
     hide_pause = false # Change to true to hide the pause button
     hide_skip = false  # Change to true to hide the skip button 
     style = dark.css   # Stylesheet to use. Also embedded is original.css (light theme)
+	max_results = 50   # Maximum number of tracks to show when searching / browsing on a single page
 
 Project resources
 =================
@@ -50,6 +51,18 @@ Project resources
 - `Source code <https://github.com/Lesterpig/mopidy-party>`_
 - `Issue tracker <https://github.com/Lesterpig/mopidy-party/issues>`_
 - `Development branch tarball <https://github.com/Lesterpig/mopidy-party/archive/master.tar.gz#egg=Mopidy-Party-dev>`_
+
+
+Developer information
+=====================
+
+The RequestHandler 'config' makes `mopidy.conf` `[party]` configuration available via `http GET` requests. Useful if you want to make aspects of the controller configurable.
+
+Example: The controller uses the below request, to read the `mopidy.conf` `[party]` section's `max_results` value.
+.. code-block:: javascript
+
+$http.get('/party/config?key=max_results')
+ 
 
 Changelog
 =========

--- a/mopidy_party/static/controller.js
+++ b/mopidy_party/static/controller.js
@@ -2,252 +2,247 @@
 
 // TODO : add a mopidy service designed for angular, to avoid ugly $scope.$apply()...
 angular.module('partyApp', [])
-  .controller('MainController', function($scope, $http, $timeout) {
+  .controller('MainController', function($scope, $http, $timeout){
 
-  // Scope variables
-  $scope.message = [];
-  $scope.tracks  = [];
-  $scope.tracksToLookup = [];
-  $scope.maxTracksToLookupAtOnce = 50; //note: will be overwritten by config value
-  $scope.loading = true;
-  $scope.ready   = false;
-  $scope.currentState = {
-    paused : false,
-    length : 0,
-    track  : {
-      length : 0,
-      name   : 'Nothing playing, add some songs to get the party going!'
-    }
-  };
-
-  //Get the max tracks to lookup at once from the "max_results" config value in mopidy.conf
-  $http.get('/party/config?key=max_results').then(function success(response){
-	if (response.status == 200) {
-		$scope.maxTracksToLookupAtOnce = response.data;
-	}
-  }, null);
-
-
-  // Initialize
-
-  var mopidy = new Mopidy({
-    'callingConvention' : 'by-position-or-by-name'
-  });
-
-  // Adding listenners
-
-  mopidy.on('state:online', function () {
-    mopidy.playback
-    .getCurrentTrack()
-    .then(function(track){
-      if(track)
-        $scope.currentState.track = track;
-      return mopidy.playback.getState();
-    })
-    .then(function(state){
-      $scope.currentState.paused = (state === 'paused');
-      return mopidy.tracklist.getLength();
-    })
-    .then(function(length){
-      $scope.currentState.length = length;
-    })
-    .done(function(){
-      $scope.ready   = true;
-      $scope.loading = false;
-      $scope.$apply();
-      $scope.search();
-    });
-  });
-  mopidy.on('event:playbackStateChanged', function(event){
-    $scope.currentState.paused = (event.new_state === 'paused');
-    $scope.$apply();
-  });
-  mopidy.on('event:trackPlaybackStarted', function(event){
-    $scope.currentState.track = event.tl_track.track;
-    $scope.$apply();
-  });
-  mopidy.on('event:tracklistChanged', function(){
-    mopidy.tracklist.getLength().done(function(length){
-      $scope.currentState.length = length;
-      $scope.$apply();
-    });
-  });
-  
-  $scope.printDuration = function(track){
-
-    if(!track.length)
-      return '';
-
-    var _sum = parseInt(track.length / 1000);
-    var _min = parseInt(_sum / 60);
-    var _sec = _sum % 60;
-
-    return '(' + _min + ':' + (_sec < 10 ? '0' + _sec : _sec) + ')' ;
-  };
-  
-  $scope.search = function(){
-
+    // Scope variables
     $scope.message = [];
-    $scope.loading = true;
-
-    if(!$scope.searchField) {
-      mopidy.library.browse({
-        'uri' : 'local:directory'
-      }).done($scope.handleBrowseResult);
-      return;
-    }
-
-    mopidy.library.search({
-      'query': {
-        'any' : [$scope.searchField]
-      }
-    }).done($scope.handleSearchResult);
-  };
-
-  $scope.handleBrowseResult = function(res){
-    $scope.loading = false;
     $scope.tracks  = [];
     $scope.tracksToLookup = [];
-
-    for(var i = 0; i < res.length; i++){
-      if(res[i].type == 'directory' && res[i].uri == 'local:directory?type=track'){
-        mopidy.library.browse({
-          'uri' : res[i].uri
-        }).done($scope.handleBrowseResult);
-      } else if(res[i].type == 'track'){
-        $scope.tracksToLookup.push(res[i].uri);
+    $scope.maxTracksToLookupAtOnce = 50; //note: will be overwritten by config value
+    $scope.loading = true;
+    $scope.ready   = false;
+    $scope.currentState = {
+      paused : false,
+      length : 0,
+      track  : {
+        length : 0,
+        name   : 'Nothing playing, add some songs to get the party going!'
       }
-    }
-	$scope.$apply();
-	$timeout(function() {
-		if($scope.tracksToLookup) {
-			$scope.lookupOnePageOfTracks();
-		}
-	}, 0);
-  }
+    };
 
-  $scope.lookupOnePageOfTracks = function(){
-	//wrap in timeout to avoid nested $apply problems
-    $timeout(function() {
-	//the splice function returns and removes the elements from the list of tracks to show in one page
-	mopidy.library.lookup({'uris' : $scope.tracksToLookup.splice(0, $scope.maxTracksToLookupAtOnce)}).done(function(tracklistResult){
-		//mopidy.library.lookup delivers a JSON object, we unwrap it with Object.values() into an array.
-		//Each result is an array in itself, where the first (0'th) element is a track object, so we convert the result array using a 
-		//simple lambda function that converts each result to the track-part only (0'th element).
-		var browseTracklist = Object.values(tracklistResult).map((singleTrackResult) => singleTrackResult[0]);
-		for(var j = 0; j < browseTracklist.length; j++){
-          $scope.addTrackResult(browseTracklist[j]);
-        }
+    //Get the max tracks to lookup at once from the "max_results" config value in mopidy.conf
+    $http.get('/party/config?key=max_results').then(function success(response){
+      if(response.status == 200){
+        $scope.maxTracksToLookupAtOnce = response.data;
+      }
+    }, null);
+
+
+    // Initialize
+
+    var mopidy = new Mopidy({
+      'callingConvention' : 'by-position-or-by-name'
     });
-    //$scope.$apply();
-	}, 0);
-  };
 
+    // Adding listenners
 
-  $scope.handleSearchResult = function(res){
+    mopidy.on('state:online', function(){
+      mopidy.playback
+        .getCurrentTrack()
+        .then(function(track){
+          if(track)
+            $scope.currentState.track = track;
+          return mopidy.playback.getState();
+        })
+        .then(function(state){
+          $scope.currentState.paused = (state === 'paused');
+          return mopidy.tracklist.getLength();
+        })
+        .then(function(length){
+          $scope.currentState.length = length;
+        })
+        .done(function(){
+          $scope.ready   = true;
+          $scope.loading = false;
+          $scope.$apply();
+          $scope.search();
+        });
+    });
+    mopidy.on('event:playbackStateChanged', function(event){
+      $scope.currentState.paused = (event.new_state === 'paused');
+      $scope.$apply();
+    });
+    mopidy.on('event:trackPlaybackStarted', function(event){
+      $scope.currentState.track = event.tl_track.track;
+      $scope.$apply();
+    });
+    mopidy.on('event:tracklistChanged', function(){
+      mopidy.tracklist.getLength().done(function(length){
+        $scope.currentState.length = length;
+        $scope.$apply();
+      });
+    });
 
-    $scope.loading = false;
-    $scope.tracks  = [];
-	$scope.tracksToLookup = [];
+    $scope.printDuration = function(track){
 
-    var _index = 0;
-    var _found = true;
-    while(_found){
-      _found = false;
+      if(!track.length)
+        return '';
+
+      var _sum = parseInt(track.length / 1000);
+      var _min = parseInt(_sum / 60);
+      var _sec = _sum % 60;
+
+      return '(' + _min + ':' + (_sec < 10 ? '0' + _sec : _sec) + ')';
+    };
+
+    $scope.search = function(){
+
+      $scope.message = [];
+      $scope.loading = true;
+
+      if(!$scope.searchField){
+        mopidy.library.browse({
+          'uri': 'local:directory'
+        }).done($scope.handleBrowseResult);
+        return;
+      }
+
+      mopidy.library.search({
+        'query': {
+          'any': [$scope.searchField]
+        }
+      }).done($scope.handleSearchResult);
+    };
+
+    $scope.handleBrowseResult = function(res){
+      $scope.loading = false;
+      $scope.tracks = [];
+      $scope.tracksToLookup = [];
+
       for(var i = 0; i < res.length; i++){
-        if(res[i].tracks && res[i].tracks[_index]){
-          $scope.addTrackResult(res[i].tracks[_index]);
-          _found = true;
+        if(res[i].type == 'directory' && res[i].uri == 'local:directory?type=track'){
+          mopidy.library.browse({
+            'uri': res[i].uri
+          }).done($scope.handleBrowseResult);
+        } else if(res[i].type == 'track'){
+          $scope.tracksToLookup.push(res[i].uri);
         }
       }
-      _index++;
+      $scope.$apply();
+      $timeout(function(){
+        if($scope.tracksToLookup){
+          $scope.lookupOnePageOfTracks();
+        }
+      }, 0);
     }
-    $scope.$apply();
-  };
 
-  $scope.addTrackResult = function(track){
-    $scope.tracks.push(track);
-	mopidy.tracklist.filter([{'uri': [track.uri]}]).done(
-      function(matches){
-        if (matches.length) {
-          for (var i = 0; i < $scope.tracks.length; i++)
-          {
-            if ($scope.tracks[i].uri == matches[0].track.uri)
-              $scope.tracks[i].disabled = true;
+    $scope.lookupOnePageOfTracks = function(){
+      //wrap in timeout to avoid nested $apply problems
+      $timeout(function(){
+        //the splice function returns and removes the elements from the list of tracks to show in one page
+        mopidy.library.lookup({ 'uris': $scope.tracksToLookup.splice(0, $scope.maxTracksToLookupAtOnce) }).done(function(tracklistResult){
+          //mopidy.library.lookup delivers a JSON object, we unwrap it with Object.values() into an array.
+          //Each result is an array in itself, where the first (0'th) element is a track object, so we convert the result array using a 
+          //simple lambda function that converts each result to the track-part only (0'th element).
+          var browseTracklist = Object.values(tracklistResult).map((singleTrackResult) => singleTrackResult[0]);
+          for(var j = 0; j < browseTracklist.length; j++){
+            $scope.addTrackResult(browseTracklist[j]);
+          }
+        });
+        //$scope.$apply();
+      }, 0);
+    };
+
+
+    $scope.handleSearchResult = function(res){
+
+      $scope.loading = false;
+      $scope.tracks  = [];
+      $scope.tracksToLookup = [];
+
+      var _index = 0;
+      var _found = true;
+      while(_found){
+        _found = false;
+        for(var i = 0; i < res.length; i++){
+          if(res[i].tracks && res[i].tracks[_index]){
+            $scope.addTrackResult(res[i].tracks[_index]);
+            _found = true;
           }
         }
-      });
-    $scope.$apply();
-  };
+        _index++;
+      }
+      $scope.$apply();
+    };
 
-  $scope.addTrack = function(track){
-    track.disabled = true;
+    $scope.addTrackResult = function(track){
+      $scope.tracks.push(track);
+      mopidy.tracklist.filter([{ 'uri': [track.uri] }]).done(
+        function(matches){
+          if(matches.length){
+            for(var i = 0; i < $scope.tracks.length; i++){
+              if($scope.tracks[i].uri == matches[0].track.uri)
+                $scope.tracks[i].disabled = true;
+            }
+          }
+          $scope.$apply();
+        });
+    };
 
-	$http.post('/party/add', track.uri).then(
-		function success(response){
-			$timeout(function() {
-				if (response.status < 400) {
-					$scope.message = ['success', 'Queued: ' + track.name];
-				} else {
-					$scope.message = ['success', 'Queued: ' + track.name + ' - ' + response.data];
-				}
-				//$scope.$apply();
-			}, 0);
-		}, 
-		function error(response){
-			$timeout(function() {
-				if (response.status === 409) {
-					$scope.message = ['error', '' + response.data];
-				} else {
-					$scope.message = ['error', 'Code ' + response.status + ' - ' + response.data];
-				}
-				//$scope.$apply();
-			}, 0);
-		} 
-	);
-  };
+    $scope.addTrack = function(track){
+      track.disabled = true;
 
-  $scope.nextTrack = function(){
-    $http.get('/party/vote').then(
-		function success(response){
-			$timeout(function() {
-				$scope.message = ['success', '' + response.data];
-				//$scope.$apply();
-			}, 0);
-		}, 
-		function error(response){
-			$timeout(function() {
-				$scope.message = ['error', '' + response.data];
-				//$scope.$apply();
-			}, 0);
-		} 
-	);
-  };
-  
-  $scope.getTrackSource = function(track){
-    var sourceAsText = "unknown";
-    if (track.uri) {
-      sourceAsText = track.uri.split(":", "1")[0];
-    }
-    return sourceAsText;
-  };
-  
-    
-  $scope.getFontAwesomeIcon = function(source){
-    var sources_with_fa_icon = ["bandcamp", "mixcloud", "soundcloud", "spotify", "youtube"];
-    var css_class =  "fa fa-music";
-    if (source == "local") {
-      css_class = "fa fa-folder";
-    } else if (sources_with_fa_icon.includes(source)) {
-      css_class = "fa-brands fa-"+source;
-    }
-    return css_class;
-  };
+      $http.post('/party/add', track.uri).then(
+        function success(response){
+          $timeout(function(){
+            $scope.message = ['success', 'Queued: ' + track.name];
+            //$scope.$apply();
+          }, 0);
+        },
+        function error(response){
+          $timeout(function(){
+            if(response.status === 409){
+              $scope.message = ['error', '' + response.data];
+            } else {
+              $scope.message = ['error', 'Code ' + response.status + ' - ' + response.data];
+            }
+            //$scope.$apply();
+          }, 0);
+        }
+      );
+    };
+
+    $scope.nextTrack = function(){
+      $http.get('/party/vote').then(
+        function success(response){
+          $timeout(function(){
+            $scope.message = ['success', '' + response.data];
+            //$scope.$apply();
+          }, 0);
+        },
+        function error(response){
+          $timeout(function(){
+            $scope.message = ['error', '' + response.data];
+            //$scope.$apply();
+          }, 0);
+        }
+      );
+    };
+
+    $scope.getTrackSource = function(track){
+      var sourceAsText = "unknown";
+      if(track.uri){
+        sourceAsText = track.uri.split(":", "1")[0];
+      }
+      return sourceAsText;
+    };
 
 
-  $scope.togglePause = function(){
-    var _fn = $scope.currentState.paused ? mopidy.playback.resume : mopidy.playback.pause;
-    _fn().done();
-  };
+    $scope.getFontAwesomeIcon = function(source){
+      var sources_with_fa_icon = ["bandcamp", "mixcloud", "soundcloud", "spotify", "youtube"];
+      var css_class = "fa fa-music";
+      if(source == "local"){
+        css_class = "fa fa-folder";
+      } else if(sources_with_fa_icon.includes(source)){
+        css_class = "fa-brands fa-" + source;
+      }
+      return css_class;
+    };
 
-});
+
+    $scope.togglePause = function(){
+      var _fn = $scope.currentState.paused ? mopidy.playback.resume : mopidy.playback.pause;
+      _fn().done();
+    };
+
+  });

--- a/mopidy_party/static/controller.js
+++ b/mopidy_party/static/controller.js
@@ -2,13 +2,13 @@
 
 // TODO : add a mopidy service designed for angular, to avoid ugly $scope.$apply()...
 angular.module('partyApp', [])
-  .controller('MainController', function($scope) {
+  .controller('MainController', function($scope, $http) {
 
   // Scope variables
   $scope.message = [];
   $scope.tracks  = [];
   $scope.tracksToLookup = [];
-  $scope.maxTracksToLookupAtOnce = 50;
+  $scope.maxTracksToLookupAtOnce = 50; //note: will be overwritten by config value
   $scope.loading = true;
   $scope.ready   = false;
   $scope.currentState = {
@@ -19,6 +19,14 @@ angular.module('partyApp', [])
       name   : 'Nothing playing, add some songs to get the party going!'
     }
   };
+
+  //Get the max tracks to lookup at once from the "max_results" config value in mopidy.conf
+  $http.get('/party/config?key=max_results').then(function success(response){
+	if (response.status == 200) {
+		$scope.maxTracksToLookupAtOnce = response.data;
+	}
+  }, null);
+
 
   // Initialize
 
@@ -116,7 +124,8 @@ angular.module('partyApp', [])
   }
 
   $scope.lookupOnePageOfTracks = function(){
-	mopidy.library.lookup({'uris' : $scope.tracksToLookup.slice(0, $scope.maxTracksToLookupAtOnce)}).done(function(tracklistResult){
+	//the splice function returns and removes the elements from the list of tracks to show in one page
+	mopidy.library.lookup({'uris' : $scope.tracksToLookup.splice(0, $scope.maxTracksToLookupAtOnce)}).done(function(tracklistResult){
 		//mopidy.library.lookup delivers a JSON object, we unwrap it with Object.values() into an array.
 		//Each result is an array in itself, where the first (0'th) element is a track object, so we convert the result array using a 
 		//simple lambda function that converts each result to the track-part only (0'th element).


### PR DESCRIPTION
Fixed and simplified browse-results logic (using splice instead of shift).
Fixed the use of tracklist.filter when adding track search/browse results (input requirement is list instead of object)
Changed message wording on add track from 'Next' to 'Queued'
Added cfg read service. 
Added new max_results and max_queue_length config.
Setting max_results in controller via cfg service.
With browser console I discovered some AngularJS errors regarding nested use of $scope.$apply. Got around them by using the AngularJS $timeout functionality.
Changed HTTP return codes to be more true to the official code definitions (i.e. a problem with queing due to max length or max number of items per user, should be 409 (conflict), rather than 400 (bad request)
Changed addtrack and vote skip controller.js calls to the backend to use asynchronous AngularJS $http rather than synchronous deprecated XMLHTTPRequest.